### PR TITLE
9. basic a11y for our components

### DIFF
--- a/src/UniqueID.js
+++ b/src/UniqueID.js
@@ -1,0 +1,12 @@
+let UUID = 0;
+
+export default function UniqueID() {
+  const getID = () => {
+    UUID++;
+    return UUID;
+  };
+
+  return {
+    getID
+  };
+}

--- a/src/components/BaseInput.vue
+++ b/src/components/BaseInput.vue
@@ -1,15 +1,27 @@
 <template>
-  <label v-if="label">{{ label }}</label>
+  <label :for="uuid" v-if="label">{{ label }}</label>
   <input
     v-bind="$attrs"
     :value="modelValue"
     @input="$emit('update:modelValue', $event.target.value)"
     :placeholder="label"
     class="field"
+    :id="uuid"
+    :aria-describedby="error ? `${uuid}-error` : null"
+    :aria-invalid="error ? 'true' : null"
   />
+  <p
+    v-if="error"
+    class="errorMessage"
+    :id="`${uuid}-error`"
+    aria-live="assertive"
+  >
+    {{ error }}
+  </p>
 </template>
 
 <script>
+import UniqueID from "../UniqueID";
 export default {
   props: {
     label: {
@@ -19,7 +31,17 @@ export default {
     modelValue: {
       type: [String, Number],
       default: ""
+    },
+    error: {
+      type: String,
+      default: ""
     }
+  },
+  setup() {
+    const uuid = UniqueID().getID();
+    return {
+      uuid
+    };
   }
 };
 </script>

--- a/src/views/SimpleForm.vue
+++ b/src/views/SimpleForm.vue
@@ -8,38 +8,56 @@
         label="Select a category"
       />
 
-      <h3>Name & describe your event</h3>
+      <fieldset>
+        <legend>Name & describe your event</legend>
 
-      <BaseInput v-model="event.title" label="Title" type="text" />
-
-      <BaseInput v-model="event.description" label="Desctiption" type="text" />
-
-      <h3>Where is your event?</h3>
-
-      <BaseInput v-model="event.location" label="Location" type="text" />
-
-      <h3>Are pets allowed?</h3>
-      <div>
-        <BaseRadioGroup
-          v-model="event.pets"
-          name="pets"
-          :options="petOptions"
+        <BaseInput
+          v-model="event.title"
+          label="Title"
+          type="text"
+          error="This input has an error!"
         />
-      </div>
 
-      <h3>Extras</h3>
-      <div>
-        <BaseCheckBox v-model="event.extras.catering" label="Catering" />
-      </div>
+        <BaseInput
+          v-model="event.description"
+          label="Description"
+          type="text"
+        />
+      </fieldset>
 
-      <div>
-        <BaseCheckBox v-model="event.extras.music" label="Live music" />
-      </div>
+      <fieldset>
+        <legend>Where is your event?</legend>
 
-      <pre>{{ JSON.stringify(event, null, 2) }}</pre>
+        <BaseInput v-model="event.location" label="Location" type="text" />
+      </fieldset>
+
+      <fieldset>
+        <legend>Pets</legend>
+        <p>Are pets allowed?</p>
+        <div>
+          <BaseRadioGroup
+            v-model="event.pets"
+            name="pets"
+            :options="petOptions"
+          />
+        </div>
+      </fieldset>
+
+      <fieldset>
+        <legend>Extras</legend>
+        <div>
+          <BaseCheckBox v-model="event.extras.catering" label="Catering" />
+        </div>
+
+        <div>
+          <BaseCheckBox v-model="event.extras.music" label="Live music" />
+        </div>
+      </fieldset>
 
       <button class="button -fill-gradient" type="submit">Submit</button>
     </form>
+
+    <pre>{{ JSON.stringify(event, null, 2) }}</pre>
   </div>
 </template>
 
@@ -92,3 +110,17 @@ export default {
   }
 };
 </script>
+
+<style>
+fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+legend {
+  font-size: 28px;
+  font-weight: 700;
+  margin-top: 20px;
+}
+</style>


### PR DESCRIPTION

- `fieldset` と `legend` タグでグループ化
- エラーが出てるinputタグに`aria-invalid`  を付与してinputタグがエラー箇所であることを明示
- 同じくinputタグに `aria-describedby` を付与してエラーメッセージと紐づける
- エラーメッセージを `aria-live="assertive"` でスクリーンリーダーに即座に伝える
ref. [ARIA ライブリージョン - アクセシビリティ | MDN](https://developer.mozilla.org/ja/docs/Web/Accessibility/ARIA/ARIA_Live_Regions#%E5%84%AA%E5%85%88%E3%81%99%E3%82%8B%E5%B0%82%E9%96%80%E3%81%AE%E3%83%A9%E3%82%A4%E3%83%96%E3%83%AA%E3%83%BC%E3%82%B8%E3%83%A7%E3%83%B3%E3%83%AD%E3%83%BC%E3%83%AB)
- UUIDは擬似的に作る

Firefoxのアクセシビリティパネルの「states」はChromeにはない？
![image](https://user-images.githubusercontent.com/14849535/199001489-353e60aa-2cc7-426f-adb5-23a7032ba94b.png)
